### PR TITLE
Give `description` for easier debugging.

### DIFF
--- a/simple-concat.js
+++ b/simple-concat.js
@@ -11,6 +11,8 @@ module.exports = CachingWriter.extend({
   enforceSingleInputTree: true,
 
   init: function() {
+    this.description = 'SourcemapConcat';
+    
     if (!this.separator) {
       this.separator = '\n';
     }


### PR DESCRIPTION
Without this the slow tree printout simply labels this as `Class` (from the CoreObject constructor function).
