### PR TITLE
Upgraded fast-sourcemap-concat to 0.2.4 to fix issue reported in ember-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "broccoli-kitchen-sink-helpers": "^0.2.5",
     "broccoli-writer": "^0.1.1",
     "combined-stream": "0.0.7",
-    "fast-sourcemap-concat": " ^0.2.0",
+    "fast-sourcemap-concat": " ^0.2.4",
     "lodash-node": "^2.4.1",
     "mkdirp": "^0.5.0",
     "rsvp": "^3.0.14"


### PR DESCRIPTION
Hoping it will help us push out fix to https://github.com/ember-cli/ember-cli/issues/3098#issuecomment-74359080 sooner.
