### PR TITLE
Update to broccoli-caching-writer 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ line-to-line contenation.
 It discovers input sourcemaps in relative URLs, including data URIs.
 
 ```js
-var tree = concat(tree, {
+var node = concat(node, {
   outputFile: '/output.js',
   inputFiles: ['loader.js', '**/*']
 });

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var ConcatWithMaps = require('./concat-with-maps');
 var SimpleConcat = require('./simple-concat');
 var merge = require('lodash-node/modern/objects/merge');
 
-module.exports = function(inputTree, options) {
+module.exports = function(inputNode, options) {
   if (!options || !options.outputFile) {
     throw new Error("outputFile is required");
   }
@@ -13,10 +13,10 @@ module.exports = function(inputTree, options) {
     for (var i=0; i<extensions.length; i++) {
       var ext = '.' + extensions[i].replace(/^\./,'');
       if (options.outputFile.slice(-1 * ext.length) === ext) {
-        return new ConcatWithMaps(inputTree, options);
+        return new ConcatWithMaps(inputNode, options);
       }
     }
   }
 
-  return new SimpleConcat(inputTree, options);
+  return new SimpleConcat(inputNode, options);
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "sinon": "^1.12.2"
   },
   "dependencies": {
-    "broccoli-caching-writer": "^1.0.0",
+    "broccoli-caching-writer": "^2.0.0",
     "broccoli-kitchen-sink-helpers": "^0.2.5",
     "broccoli-writer": "^0.1.1",
     "fast-sourcemap-concat": " ^0.2.4",

--- a/simple-concat.js
+++ b/simple-concat.js
@@ -20,23 +20,31 @@ Combined.prototype.toString = function() {
   return this._internal;
 };
 
-module.exports = CachingWriter.extend({
-  enforceSingleInputTree: true,
+module.exports = SimpleConcat;
+SimpleConcat.prototype = Object.create(CachingWriter.prototype);
+SimpleConcat.prototype.constructor = SimpleConcat;
+function SimpleConcat(inputNode, options) {
+  if (!(this instanceof SimpleConcat)) return new SimpleConcat(inputNode, options);
+  if (!options || !options.outputFile || !options.inputFiles) {
+    throw new Error('inputFiles and outputFile options ware required');
+  }
 
-  init: function() {
-    this._super.apply(this, arguments);
+  CachingWriter.call(this, [inputNode], {
+    inputFiles: options.inputFiles,
+    annotation: options.annotation
+  });
 
-    if (!this.separator) {
-      this.separator = '\n';
-    }
+  this.inputFiles = options.inputFiles;
+  this.outputFile = options.outputFile;
+  this.allowNone = options.allowNone;
+  this.header = options.header;
+  this.headerFiles = options.headerFiles;
+  this.footer = options.footer;
+  this.footerFiles = options.footerFiles;
+  this.separator = (options.separator != null) ? options.separator : '\n';
+}
 
-    if (!this.outputFile) {
-      throw new Error('outputFile is required');
-    }
-  },
-
-  description: 'SimpleConcat',
-  updateCache: function(inDir, outDir) {
+SimpleConcat.prototype.build = function() {
     var combined = new Combined();
     var firstSection = true;
     var separator = this.separator;
@@ -57,12 +65,12 @@ module.exports = CachingWriter.extend({
     if (this.headerFiles) {
       this.headerFiles.forEach(function(file) {
         beginSection();
-        combined.append(fs.readFileSync(path.join(inDir, file), 'UTF-8'));
+        combined.append(fs.readFileSync(path.join(this.inputPaths[0], file), 'UTF-8'));
       });
     }
 
     try {
-      this._addFiles(combined, inDir, beginSection);
+      this._addFiles(combined, this.inputPaths[0], beginSection);
     } catch(error) {
       // multiGlob is obtuse.
       if (!error.message.match('did not match any files') || !this.allowNone) {
@@ -78,11 +86,11 @@ module.exports = CachingWriter.extend({
     if (this.footerFiles) {
       this.footerFiles.forEach(function(file) {
         beginSection();
-        combined.append(fs.readFileSync(path.join(inDir, file), 'UTF-8'));
+        combined.append(fs.readFileSync(path.join(this.inputPaths[0], file), 'UTF-8'));
       }.bind(this));
     }
 
-    var filePath = path.join(outDir, this.outputFile);
+    var filePath = path.join(this.outputPath, this.outputFile);
 
     mkdirp.sync(path.dirname(filePath));
 
@@ -91,15 +99,15 @@ module.exports = CachingWriter.extend({
     }
 
     fs.writeFileSync(filePath, combined);
-  },
+}
 
-  _addFiles: function(combined, inDir, beginSection) {
+SimpleConcat.prototype._addFiles = function(combined, inputPath, beginSection) {
     helpers.multiGlob(this.inputFiles, {
-      cwd: inDir,
-      root: inDir,
+      cwd: inputPath,
+      root: inputPath,
       nomount: false
     }).forEach(function(file) {
-      var filePath = path.join(inDir, file);
+      var filePath = path.join(inputPath, file);
       var stat;
 
       try {
@@ -114,4 +122,3 @@ module.exports = CachingWriter.extend({
 
     return combined;
   }
-});

--- a/simple-concat.js
+++ b/simple-concat.js
@@ -45,80 +45,80 @@ function SimpleConcat(inputNode, options) {
 }
 
 SimpleConcat.prototype.build = function() {
-    var combined = new Combined();
-    var firstSection = true;
-    var separator = this.separator;
+  var combined = new Combined();
+  var firstSection = true;
+  var separator = this.separator;
 
-    function beginSection() {
-      if (firstSection) {
-        firstSection = false;
-      } else {
-        combined.append(separator);
-      }
-    }
-
-    if (this.header) {
-      beginSection();
-      combined.append(this.header);
-    }
-
-    if (this.headerFiles) {
-      this.headerFiles.forEach(function(file) {
-        beginSection();
-        combined.append(fs.readFileSync(path.join(this.inputPaths[0], file), 'UTF-8'));
-      });
-    }
-
-    try {
-      this._addFiles(combined, this.inputPaths[0], beginSection);
-    } catch(error) {
-      // multiGlob is obtuse.
-      if (!error.message.match('did not match any files') || !this.allowNone) {
-        throw error;
-      }
-    }
-
-    if (this.footer) {
-      beginSection();
-      combined.append(this.footer);
-    }
-
-    if (this.footerFiles) {
-      this.footerFiles.forEach(function(file) {
-        beginSection();
-        combined.append(fs.readFileSync(path.join(this.inputPaths[0], file), 'UTF-8'));
-      }.bind(this));
-    }
-
-    var filePath = path.join(this.outputPath, this.outputFile);
-
-    mkdirp.sync(path.dirname(filePath));
-
+  function beginSection() {
     if (firstSection) {
-      combined.append('');
+      firstSection = false;
+    } else {
+      combined.append(separator);
     }
+  }
 
-    fs.writeFileSync(filePath, combined);
+  if (this.header) {
+    beginSection();
+    combined.append(this.header);
+  }
+
+  if (this.headerFiles) {
+    this.headerFiles.forEach(function(file) {
+      beginSection();
+      combined.append(fs.readFileSync(path.join(this.inputPaths[0], file), 'UTF-8'));
+    });
+  }
+
+  try {
+    this._addFiles(combined, this.inputPaths[0], beginSection);
+  } catch(error) {
+    // multiGlob is obtuse.
+    if (!error.message.match('did not match any files') || !this.allowNone) {
+      throw error;
+    }
+  }
+
+  if (this.footer) {
+    beginSection();
+    combined.append(this.footer);
+  }
+
+  if (this.footerFiles) {
+    this.footerFiles.forEach(function(file) {
+      beginSection();
+      combined.append(fs.readFileSync(path.join(this.inputPaths[0], file), 'UTF-8'));
+    }.bind(this));
+  }
+
+  var filePath = path.join(this.outputPath, this.outputFile);
+
+  mkdirp.sync(path.dirname(filePath));
+
+  if (firstSection) {
+    combined.append('');
+  }
+
+  fs.writeFileSync(filePath, combined);
 }
 
 SimpleConcat.prototype._addFiles = function(combined, inputPath, beginSection) {
-    helpers.multiGlob(this.inputFiles, {
-      cwd: inputPath,
-      root: inputPath,
-      nomount: false
-    }).forEach(function(file) {
-      var filePath = path.join(inputPath, file);
-      var stat;
+  helpers.multiGlob(this.inputFiles, {
+    cwd: inputPath,
+    root: inputPath,
+    nomount: false
+  }).forEach(function(file) {
+    var filePath = path.join(inputPath, file);
+    var stat;
 
-      try {
-        stat = fs.statSync(filePath);
-      } catch(err) {}
+    try {
+      stat = fs.statSync(filePath);
+    } catch(err) {}
 
-      if (stat && !stat.isDirectory()) {
-        beginSection();
-        combined.append(fs.readFileSync(filePath, 'UTF-8'));
-      }
-    });
+    if (stat && !stat.isDirectory()) {
+      beginSection();
+      combined.append(fs.readFileSync(filePath, 'UTF-8'));
+    }
+  });
 
-    return combined;
-  }
+  return combined;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -13,11 +13,11 @@ var builder;
 
 describe('sourcemap-concat', function() {
   it('concatenates files in one dir', function() {
-    var tree = concat(fixtures, {
+    var node = concat(fixtures, {
       outputFile: '/all-inner.js',
       inputFiles: ['inner/*.js']
     });
-    builder = new broccoli.Builder(tree);
+    builder = new broccoli.Builder(node);
     return builder.build().then(function(result) {
       expectFile('all-inner.js').in(result);
       expectFile('all-inner.map').in(result);
@@ -25,11 +25,11 @@ describe('sourcemap-concat', function() {
   });
 
   it('concatenates files across dirs', function() {
-    var tree = concat(fixtures, {
+    var node = concat(fixtures, {
       outputFile: '/all.js',
       inputFiles: ['**/*.js']
     });
-    builder = new broccoli.Builder(tree);
+    builder = new broccoli.Builder(node);
     return builder.build().then(function(result) {
       expectFile('all.js').in(result);
       expectFile('all.map').in(result);
@@ -37,12 +37,12 @@ describe('sourcemap-concat', function() {
   });
 
   it('inserts header', function() {
-    var tree = concat(fixtures, {
+    var node = concat(fixtures, {
       outputFile: '/all-with-header.js',
       inputFiles: ['**/*.js'],
       header: "/* This is my header. */"
     });
-    builder = new broccoli.Builder(tree);
+    builder = new broccoli.Builder(node);
     return builder.build().then(function(result) {
       expectFile('all-with-header.js').in(result);
       expectFile('all-with-header.map').in(result);
@@ -50,13 +50,13 @@ describe('sourcemap-concat', function() {
   });
 
   it('inserts header when sourcemaps are disabled', function() {
-    var tree = concat(fixtures, {
+    var node = concat(fixtures, {
       outputFile: '/all-with-header.js',
       inputFiles: ['**/*.js'],
       header: "/* This is my header. */",
       sourceMapConfig: { enabled: false }
     });
-    builder = new broccoli.Builder(tree);
+    builder = new broccoli.Builder(node);
     return builder.build().then(function(result) {
       expectFile('all-with-header.js').withoutSrcURL().in(result);
       expectFile('all-with-header.map').notIn(result);
@@ -64,13 +64,13 @@ describe('sourcemap-concat', function() {
   });
 
   it('disables sourcemaps when requested', function() {
-    var tree = concat(fixtures, {
+    var node = concat(fixtures, {
       outputFile: '/no-sourcemap.js',
       inputFiles: ['**/*.js'],
       header: "/* This is my header. */",
       sourceMapConfig: { extensions: [] }
     });
-    builder = new broccoli.Builder(tree);
+    builder = new broccoli.Builder(node);
     return builder.build().then(function(result) {
       expectFile('no-sourcemap.js').in(result);
       expectFile('no-sourcemap.map').notIn(result);
@@ -101,12 +101,12 @@ describe('sourcemap-concat', function() {
   });
 
   it('appends footer files', function() {
-    var tree = concat(fixtures, {
+    var node = concat(fixtures, {
       outputFile: '/inner-with-footers.js',
       inputFiles: ['inner/*.js'],
       footerFiles: ['other/third.js', 'other/fourth.js']
     });
-    builder = new broccoli.Builder(tree);
+    builder = new broccoli.Builder(node);
     return builder.build().then(function(result) {
       expectFile('inner-with-footers.js').in(result);
       expectFile('inner-with-footers.map').in(result);
@@ -114,13 +114,13 @@ describe('sourcemap-concat', function() {
   });
 
   it('appends footer files when sourcemaps are disabled', function() {
-    var tree = concat(fixtures, {
+    var node = concat(fixtures, {
       outputFile: '/inner-with-footers.js',
       inputFiles: ['inner/*.js'],
       footerFiles: ['other/third.js', 'other/fourth.js'],
       sourceMapConfig: { extensions: [] }
     });
-    builder = new broccoli.Builder(tree);
+    builder = new broccoli.Builder(node);
     return builder.build().then(function(result) {
       expectFile('inner-with-footers.js').withoutSrcURL().in(result);
       expectFile('inner-with-footers.map').notIn(result);
@@ -128,12 +128,12 @@ describe('sourcemap-concat', function() {
   });
 
   it('can ignore empty content', function() {
-    var tree = concat(fixtures, {
+    var node = concat(fixtures, {
       outputFile: '/nothing.js',
       inputFiles: ['nothing/*.js'],
       allowNone: true
     });
-    builder = new broccoli.Builder(tree);
+    builder = new broccoli.Builder(node);
     return builder.build().then(function(result) {
       expectFile('nothing.js').in(result);
       expectFile('nothing.map').in(result);
@@ -141,36 +141,36 @@ describe('sourcemap-concat', function() {
   });
 
   it('can ignore empty content when sourcemaps are disabled', function() {
-    var tree = concat(fixtures, {
+    var node = concat(fixtures, {
       outputFile: '/nothing.css',
       inputFiles: ['nothing/*.css'],
       allowNone: true
     });
-    builder = new broccoli.Builder(tree);
+    builder = new broccoli.Builder(node);
     return builder.build().then(function(result) {
       expectFile('nothing.css').in(result);
     });
   });
 
   it('does not ignore empty content when allowNone is not explicitly set', function() {
-    var tree = concat(fixtures, {
+    var node = concat(fixtures, {
       outputFile: '/nothing.js',
       inputFiles: ['nothing/*.js']
     });
     var failure = sinon.spy();
-    builder = new broccoli.Builder(tree);
+    builder = new broccoli.Builder(node);
     return builder.build().catch(failure).then(function(){
       expect(failure.called).to.be.true();
     });
   });
 
   it('does not ignore empty content when allowNone is not explicitly set and sourcemaps are disabled', function() {
-    var tree = concat(fixtures, {
+    var node = concat(fixtures, {
       outputFile: '/nothing.css',
       inputFiles: ['nothing/*.css']
     });
     var failure = sinon.spy();
-    builder = new broccoli.Builder(tree);
+    builder = new broccoli.Builder(node);
     return builder.build().catch(failure).then(function(){
       expect(failure.called).to.be.true();
     });


### PR DESCRIPTION
This is a backwards-compatible change - you can push it as a micro release.

I moved all indentation changes into a separate "dedent" commit so it's easier to read the diff.
