### PR TITLE
BroccoliCachingWriter already does a glob walk. We can use its public…

### DIFF
--- a/concat-with-maps.js
+++ b/concat-with-maps.js
@@ -61,14 +61,7 @@ ConcatWithMaps.prototype.build = function() {
     });
   }
 
-  try {
-    this.addFiles(this.inputPaths[0], beginSection);
-  } catch(error) {
-    // multiGlob is obtuse.
-    if (!error.message.match("did not match any files") || !this.allowNone) {
-      throw error;
-    }
-  }
+  this.addFiles(this.inputPaths[0], beginSection);
 
   if (this.footer) {
     beginSection();
@@ -81,21 +74,18 @@ ConcatWithMaps.prototype.build = function() {
     });
   }
   return this.concat.end();
-}
+};
 
 ConcatWithMaps.prototype.addFiles = function(inputPath, beginSection) {
-  helpers.multiGlob(this.inputFiles, {
-    cwd: inputPath,
-    root: inputPath,
-    nomount: false
-  }).forEach(function(file) {
-    var stat;
-    try {
-      stat = fs.statSync(path.join(inputPath, file));
-    } catch(err) {}
-    if (stat && !stat.isDirectory()) {
-      beginSection();
-      this.concat.addFile(file);
-    }
+  var files = this.listFiles();
+
+  if (files.length === 0 && !this.allowNone) {
+    throw new Error('ConcatWithMaps: nothing matched [' + this.inputFiles + ']');
+  }
+
+  files.forEach(function(file) {
+    beginSection();
+
+    this.concat.addFile(file.replace(this.inputPaths[0] + '/', ''));
   }.bind(this));
-}
+};

--- a/simple-concat.js
+++ b/simple-concat.js
@@ -69,14 +69,7 @@ SimpleConcat.prototype.build = function() {
     }, this);
   }
 
-  try {
-    this._addFiles(combined, this.inputPaths[0], beginSection);
-  } catch(error) {
-    // multiGlob is obtuse.
-    if (!error.message.match('did not match any files') || !this.allowNone) {
-      throw error;
-    }
-  }
+  this._addFiles(combined, this.inputPaths[0], beginSection);
 
   if (this.footer) {
     beginSection();
@@ -99,26 +92,19 @@ SimpleConcat.prototype.build = function() {
   }
 
   fs.writeFileSync(filePath, combined);
-}
+};
 
 SimpleConcat.prototype._addFiles = function(combined, inputPath, beginSection) {
-  helpers.multiGlob(this.inputFiles, {
-    cwd: inputPath,
-    root: inputPath,
-    nomount: false
-  }).forEach(function(file) {
-    var filePath = path.join(inputPath, file);
-    var stat;
+  var files = this.listFiles();
 
-    try {
-      stat = fs.statSync(filePath);
-    } catch(err) {}
+  if (files.length === 0 && !this.allowNone) {
+    throw new Error('SimpleConcat: nothing matched [' + this.inputFiles + ']');
+  }
 
-    if (stat && !stat.isDirectory()) {
-      beginSection();
-      combined.append(fs.readFileSync(filePath, 'UTF-8'));
-    }
+  files.forEach(function(filePath) {
+    beginSection();
+    combined.append(fs.readFileSync(filePath, 'UTF-8'));
   });
 
   return combined;
-}
+};


### PR DESCRIPTION
… API of `listFiles()` (the current builds matching inputFiles) to prevent needing to repeat ourselves.

In many scenarios our WalkSync is also faster.

in ember-cli/stress-app: this appears to shaves off 250ms -> 300ms from a 500ms incremental rebuild
